### PR TITLE
Draft version of 'insert_before_last' Liquid filter to inject content in Jekyll posts/pages

### DIFF
--- a/src/_layouts/articleStyle01.html
+++ b/src/_layouts/articleStyle01.html
@@ -17,10 +17,10 @@
 		<section class="copyDeck">
 			<div class="col col1">
 				{% capture endSign %}
-				<img class="endSign" src="{{site.data.images.endSign_diamond}}" alt=""></p>
+				<img class="endSign" src="{{site.data.images.endSign_diamond}}" alt="">
 				{% endcapture %}
 
-				{{ page.content | replace_last_instance_of: '</p>', endSign }}
+				{{ page.content | insert_before_last: '</p>', endSign }}
 
 			</div>
 		</section>

--- a/src/_plugins/insert_before_last.rb
+++ b/src/_plugins/insert_before_last.rb
@@ -1,0 +1,16 @@
+module Jekyll
+  module InsertBeforeLastFilter
+    # Inserts another string before the last occurrences of a string
+    def insert_before_last(input, string, insertion = ''.freeze)
+      # find last index of the search string
+      last_index = input.rindex(string)
+      # dissect, concat and return new string (the fastest of all benchmarks)
+      output = "#{input[0...last_index]}#{insertion}#{input[last_index...-1]}" if last_index
+      # fallback to input as-is if nothing found
+      output || input
+    end
+  end
+end
+
+# register plugin
+Liquid::Template.register_filter(Jekyll::InsertBeforeLastFilter)


### PR DESCRIPTION
Refactored your original approach a bit, to avoid repetitive calls to `reverse` since it is quite expensive.

Also, dangling `</p>` tag in the `capture` block is a maintenance problem - dangling HTML blocks always a problem.

On top of that, I did some benchmarks and got some interesting numbers, here is the summary (for `10_000_000` iterations):

```
insert_before_last: 16.820495 sec

vs.

replace_last_instance_of: 38.160341 sec
```

Let me know what you think.